### PR TITLE
Bump vintasend to 1.0.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## Version 1.0.1 (2025-09-16)
+
+* Bump vintasend version to 1.0.1
+
+
 ## Version 1.0.0 (2025-09-16)
 
 ### 🚀 Major Features

--- a/poetry.lock
+++ b/poetry.lock
@@ -939,14 +939,14 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "vintasend"
-version = "1.0.0"
+version = "1.0.1"
 description = "A flexible package for implementing transactional notifications"
 optional = false
 python-versions = "<3.14,>=3.9"
 groups = ["main"]
 files = [
-    {file = "vintasend-1.0.0-py3-none-any.whl", hash = "sha256:7f53ba9dd8cceb79625776c4d817c42d323719e89923252fec6ef86c576b95cb"},
-    {file = "vintasend-1.0.0.tar.gz", hash = "sha256:30c11dbae526ec0bab8c7ed8b96a7a30d9b9a03da19fe5806b478dd8949ef731"},
+    {file = "vintasend-1.0.1-py3-none-any.whl", hash = "sha256:b409341598bf160cd0aeafea05761eea55c7ecc5401795c7403e98c895049662"},
+    {file = "vintasend-1.0.1.tar.gz", hash = "sha256:df389c11343d91168681bd0c8e8de532c4d65c50efb18371c566f9c0e3c82ba6"},
 ]
 
 [package.dependencies]
@@ -980,4 +980,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.14,>=3.10"
-content-hash = "f78583ae5e1f0f62b8f83dd4ab00cd3cf24ce1477e29f14f314c77ffde2faf8a"
+content-hash = "7d501de11bf6fb66401ebf794d0d850ef1fa76df45fa284f163741956e475fd1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vintasend-django"
-version = "0.1.4"
+version = "1.0.1"
 description = "A flexible package for implementing transactional notifications"
 authors = ["Hugo bessa <hugo@vinta.com.br>"]
 license = "MIT"
@@ -13,7 +13,7 @@ include = [
 [tool.poetry.dependencies]
 python = "<3.14,>=3.10"
 django = "<5.3,>=3.2"
-vintasend = "1.0.0"
+vintasend = "1.0.1"
 django-model-utils = "^5.0.0"
 
 


### PR DESCRIPTION
## Summary by Sourcery

Bump the project and Vintasend dependency to version 1.0.1 and add release notes for the new version

Documentation:
- Add release notes entry for version 1.0.1

Chores:
- Bump project version and Vintasend dependency to 1.0.1